### PR TITLE
Improve helper naming and fix doc tests

### DIFF
--- a/test/doc_test.exs
+++ b/test/doc_test.exs
@@ -1,0 +1,6 @@
+defmodule DocTest do
+  use ExUnit.Case, async: true
+
+  doctest Preview
+  doctest Preview.View
+end

--- a/web/templates/layout/application.html.eex
+++ b/web/templates/layout/application.html.eex
@@ -28,7 +28,7 @@
     <div class="container">
       <div class=<%= flash_class(Flash.get(@conn)) %>>
         <div class="row">
-          <%= flash_notice(Flash.get(@conn)) %>
+          <%= flash_message(Flash.get(@conn)) %>
         </div>
       </div>
 

--- a/web/view.ex
+++ b/web/view.ex
@@ -18,13 +18,17 @@ defmodule Preview.View do
   end
 
   @doc """
-  Helper function receives the output from Flash.get(conn)
-  Maps the key to a template css class
+  Helper function to determine style class from a flash
+  Returns a string
 
-  Examples
-    iex> Flash.put(conn, :notice, "Message!")
-    iex> flash_class(Flash.get(@conn))
-    iex> "flash-notice"
+  ## Example
+
+    iex> alias Plug.Conn
+    iex> alias Phoenix.Controller.Flash
+    iex> conn = %Conn{private: %{plug_session: %{}}}
+    iex> Flash.put(conn, :error, "Message!") |> Flash.get |> Preview.View.flash_class
+    "flash-error"
+
   """
   def flash_class(map) do
     level = Map.keys(map)
@@ -39,15 +43,19 @@ defmodule Preview.View do
   end
 
   @doc """
-  Helper function takes output from Flash.get(conn)
-  Returns the message
+  Helper function to extract the message from a flash
+  Returns a list
 
-  Examples
-    iex> Flash.put(conn, :notice, "Message!")
-    iex> flash_notice(Flash.get(@conn))
-    iex> "Message!"
+  ## Example
+
+    iex> alias Plug.Conn
+    iex> alias Phoenix.Controller.Flash
+    iex> conn = %Conn{private: %{plug_session: %{}}}
+    iex> Flash.put(conn, :notice, "Message!") |> Flash.get |> Preview.View.flash_message
+    ["Message!"]
+
   """
-  def flash_notice(map) do
+  def flash_message(map) do
     map
     |> Map.values
     |> List.first


### PR DESCRIPTION
Renames view helper flash_notice/1 to flash_message/1
Includes doctests in the test run
Adds doctests for the view helper functions
